### PR TITLE
Adds support for global filters

### DIFF
--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -1,0 +1,112 @@
+import Filter from "./filters/Filter";
+
+/**
+ * @class Filterable
+ * @memberof PIXI.sound
+ * @param {AudioNode} source The source audio node
+ * @param {AudioNode} destination The output audio node
+ */
+export default class Filterable
+{
+    /**
+     * Get the gain node
+     * @name PIXI.sound.Filterable#_input
+     * @type {AudioNode}
+     * @private
+     */
+    private _input: AudioNode;
+
+    /**
+     * The destination output audio node
+     * @name PIXI.sound.Filterable#_output
+     * @type {AudioNode}
+     * @private
+     */
+    private _output: AudioNode;
+
+    /**
+     * Collection of filters.
+     * @name PIXI.sound.Filterable#_filters
+     * @type {PIXI.sound.filters.Filter[]}
+     * @private
+     */
+    private _filters: Filter[];
+
+    constructor(input: AudioNode, output: AudioNode)
+    {
+        this._output = output;
+        this._input = input;
+    }
+
+    /**
+     * The destination output audio node
+     * @name PIXI.sound.Filterable#destination
+     * @type {AudioNode}
+     * @readOnly
+     */
+    get destination(): AudioNode
+    {
+        return this._input;
+    }
+
+    /**
+     * The collection of filters
+     * @name PIXI.sound.Filterable#filters
+     * @type {PIXI.sound.filters.Filter[]}
+     */
+    get filters(): Filter[]
+    {
+        return this._filters;
+    }
+    set filters(filters: Filter[])
+    {
+        if (this._filters)
+        {
+            this._filters.forEach((filter: Filter) => {
+                if (filter)
+                {
+                    filter.disconnect();
+                }
+            });
+            this._filters = null;
+            // Reconnect direct path
+            this._input.connect(this._output);
+        }
+
+        if (filters && filters.length)
+        {
+            this._filters = filters.slice(0);
+
+            // Disconnect direct path before inserting filters
+            this._input.disconnect();
+
+            // Connect each filter
+            let prevFilter: Filter = null;
+            filters.forEach((filter: Filter) => {
+                if (prevFilter === null)
+                {
+                    // first filter is the destination
+                    // for the analyser
+                    this._input.connect(filter.destination);
+                }
+                else
+                {
+                    prevFilter.connect(filter.destination);
+                }
+                prevFilter = filter;
+            });
+            prevFilter.connect(this._output);
+        }
+    }
+
+    /**
+     * Cleans up.
+     * @method PIXI.sound.Filterable#destroy
+     */
+    public destroy(): void
+    {
+        this.filters = null;
+        this._input = null;
+        this._output = null;
+    }
+}

--- a/src/Filterable.ts
+++ b/src/Filterable.ts
@@ -1,6 +1,9 @@
 import Filter from "./filters/Filter";
 
 /**
+ * Abstract class which SoundNodes and SoundContext
+ * both extend. This provides the functionality for adding
+ * dynamic filters.
  * @class Filterable
  * @memberof PIXI.sound
  * @param {AudioNode} source The source audio node

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -331,11 +331,11 @@ export default class Sound
      */
     public get volume(): number
     {
-        return this._nodes.gainNode.gain.value;
+        return this._nodes.gain.gain.value;
     }
     public set volume(volume: number)
     {
-        this._nodes.gainNode.gain.value = volume;
+        this._nodes.gain.gain.value = volume;
     }
 
     /**

--- a/src/SoundInstance.ts
+++ b/src/SoundInstance.ts
@@ -205,7 +205,7 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
      */
     private set _enabled(enabled: boolean)
     {
-        this._parent.nodes.scriptNode.onaudioprocess = !enabled ? null : () => {
+        this._parent.nodes.script.onaudioprocess = !enabled ? null : () => {
             this._update();
         };
     }

--- a/src/SoundLibrary.ts
+++ b/src/SoundLibrary.ts
@@ -1,3 +1,4 @@
+import Filterable from "./Filterable";
 import * as filters from "./filters";
 import {Options, PlayOptions} from "./Sound";
 import Sound from "./Sound";
@@ -5,6 +6,7 @@ import SoundContext from "./SoundContext";
 import SoundInstance from "./SoundInstance";
 import SoundSprite from "./SoundSprite";
 import SoundUtils from "./SoundUtils";
+import Filter from "./filters/Filter";
 
 export type SoundMap = {[id: string]: Options|string|ArrayBuffer};
 
@@ -21,6 +23,7 @@ export default class SoundLibrary
     public SoundInstance: typeof SoundInstance;
     public SoundLibrary: typeof SoundLibrary;
     public SoundSprite: typeof SoundSprite;
+    public Filterable: typeof Filterable;
     public filters: typeof filters;
     public utils: typeof SoundUtils;
 
@@ -53,6 +56,7 @@ export default class SoundLibrary
         this.SoundInstance = SoundInstance;
         this.SoundLibrary = SoundLibrary;
         this.SoundSprite = SoundSprite;
+        this.Filterable = Filterable;
     }
 
     /**
@@ -64,6 +68,26 @@ export default class SoundLibrary
     public get context(): SoundContext
     {
         return this._context;
+    }
+
+    /**
+     * Apply filters to all sounds. Can be useful
+     * for setting global planning or global effects.
+     * @example
+     * // Adds a filter to pan all output left
+     * PIXI.sound.filtersAll = [
+     *     new PIXI.sound.filters.StereoFilter(-1)
+     * ];
+     * @name PIXI.sound#filtersAll
+     * @type {PIXI.sound.filters.Filter[]}
+     */
+    public get filtersAll(): Filter[]
+    {
+        return this._context.filters;
+    }
+    public set filtersAll(filters: Filter[])
+    {
+        this._context.filters = filters;
     }
 
     /**

--- a/src/SoundLibrary.ts
+++ b/src/SoundLibrary.ts
@@ -1,12 +1,12 @@
 import Filterable from "./Filterable";
 import * as filters from "./filters";
+import Filter from "./filters/Filter";
 import {Options, PlayOptions} from "./Sound";
 import Sound from "./Sound";
 import SoundContext from "./SoundContext";
 import SoundInstance from "./SoundInstance";
 import SoundSprite from "./SoundSprite";
 import SoundUtils from "./SoundUtils";
-import Filter from "./filters/Filter";
 
 export type SoundMap = {[id: string]: Options|string|ArrayBuffer};
 


### PR DESCRIPTION
Adds global filters through the `PIXI.sound.filtersAll` API. Addresses issue #8.

Also adds support for an analyser node on the global context `PIXI.sound.context.analyser` which can be useful for doing visualizations.