### PR TITLE
Fading Play Options

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -181,8 +181,11 @@ console.log('Sound: ', PIXI.sound.find('boing'));</code></pre>
                 </button>
 
                 <p>Create a simple sine-wave tone.</p>
-                <pre><code id="sine-tone" class="javascript">const sound = PIXI.sound.utils.sineTone(523.251);
-sound.play();</code></pre>
+                <pre><code id="sine-tone" class="javascript">const sound = PIXI.sound.utils.sineTone(523.251, 3);
+sound.play({
+    fadeIn: 1,
+    fadeOut: 1
+});</code></pre>
                 <button class="btn btn-primary" data-code="#sine-tone" data-beforeCode="#render-clear">
                     <span class="glyphicon glyphicon-play"></span> Play
                 </button>

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -559,8 +559,10 @@ export default class Sound
      * @param {Number} [options.start=0] Time when to play the sound in seconds.
      * @param {Number} [options.end] Time to end playing in seconds.
      * @param {String} [options.sprite] Play a named sprite. Will override end, start and speed options.
-     * @param {Number} [options.fadeIn] Amount of time to fade in volume. If less than 10, considered seconds or else milliseconds.
-     * @param {Number} [options.fadeOut] Amount of time to fade out volume. If less than 10, considered seconds or else milliseconds.
+     * @param {Number} [options.fadeIn] Amount of time to fade in volume. If less than 10,
+     *        considered seconds or else milliseconds.
+     * @param {Number} [options.fadeOut] Amount of time to fade out volume. If less than 10,
+     *        considered seconds or else milliseconds.
      * @param {Number} [options.speed] Override default speed, default to the Sound's speed setting.
      * @param {Boolean} [options.loop] Override default loop, default to the Sound's loop setting.
      * @param {PIXI.sound.Sound~completeCallback} [options.complete] Callback when complete.
@@ -602,7 +604,7 @@ export default class Sound
         // A sprite is specified, add the options
         if (options.sprite)
         {
-            const alias:string = options.sprite;
+            const alias: string = options.sprite;
             // @if DEBUG
             console.assert(!!this._sprites[alias], `Alias ${alias} is not available`);
             // @endif

--- a/src/SoundInstance.ts
+++ b/src/SoundInstance.ts
@@ -207,7 +207,7 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
         this._end = end;
 
         const duration: number = this._source.buffer.duration;
-        
+
         fadeIn = this._toSec(fadeIn);
 
         // Clamp fadeIn to the duration
@@ -225,7 +225,7 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
             if (fadeOut > duration - fadeIn)
             {
                 fadeOut = duration - fadeIn;
-            } 
+            }
         }
 
         this._duration = duration;
@@ -330,7 +330,7 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
                     this._speed,
                     this._source.loop,
                     this._fadeIn,
-                    this._fadeOut
+                    this._fadeOut,
                 );
             }
 
@@ -415,7 +415,7 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
                 this._lastUpdate = now;
                 const duration: number = this._duration;
                 const progress: number = ((this._elapsed * this._speed) % duration) / duration;
-                
+
                 if (this._fadeIn || this._fadeOut)
                 {
                     const position: number = progress * duration;

--- a/src/SoundInstance.ts
+++ b/src/SoundInstance.ts
@@ -91,6 +91,14 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
     private _end: number;
 
     /**
+     * `true` if should be looping.
+     * @type {Boolean}
+     * @name PIXI.sound.SoundInstance#_loop
+     * @private
+     */
+    private _loop: boolean;
+
+    /**
      * Length of the sound in seconds.
      * @type {Number}
      * @name PIXI.sound.SoundInstance#_duration
@@ -193,16 +201,16 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
         this._speed = this._source.playbackRate.value;
         if (loop !== undefined)
         {
-            this._source.loop = loop;
+            this._loop = this._source.loop = !!loop;
         }
         // WebAudio doesn't support looping when a duration is set
         // we'll set this just for the heck of it
-        if (this._source.loop && end !== undefined)
+        if (this._loop && end !== undefined)
         {
             // @if DEBUG
             console.warn('Looping not support when specifying an "end" time');
             // @endif
-            this._source.loop = false;
+            this._loop = this._source.loop = false;
         }
         this._end = end;
 
@@ -217,7 +225,7 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
         }
 
         // Cannot fade out for looping sounds
-        if (!this._source.loop)
+        if (!this._loop)
         {
             fadeOut = this._toSec(fadeOut);
 
@@ -328,7 +336,7 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
                     this._elapsed % this._duration,
                     this._end,
                     this._speed,
-                    this._source.loop,
+                    this._loop,
                     this._fadeIn,
                     this._fadeOut,
                 );
@@ -351,19 +359,13 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
     {
         this.removeAllListeners();
         this._internalStop();
-        if (this._source)
-        {
-            this._source.onended = null;
-        }
-        // reset the volume back to original
-        this._parent.volume = this._parent.volume;
-
         this._source = null;
         this._speed = 0;
         this._end = 0;
         this._parent = null;
         this._elapsed = 0;
         this._duration = 0;
+        this._loop = false;
         this._fadeIn = 0;
         this._fadeOut = 0;
         this._paused = false;
@@ -481,6 +483,9 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
             this._source.onended = null;
             this._source.stop();
             this._source = null;
+
+            // Reset the volume
+            this._parent.volume = this._parent.volume;
         }
     }
 

--- a/src/SoundInstance.ts
+++ b/src/SoundInstance.ts
@@ -59,12 +59,36 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
     private _elapsed: number;
 
     /**
+     * The number of time in seconds to fade in.
+     * @type {Number}
+     * @name PIXI.sound.SoundInstance#_fadeIn
+     * @private
+     */
+    private _fadeIn: number;
+
+    /**
+     * The number of time in seconds to fade out.
+     * @type {Number}
+     * @name PIXI.sound.SoundInstance#_fadeOut
+     * @private
+     */
+    private _fadeOut: number;
+
+    /**
      * Playback rate, where 1 is 100%.
      * @type {Number}
      * @name PIXI.sound.SoundInstance#_speed
      * @private
      */
     private _speed: number;
+
+    /**
+     * Playback rate, where 1 is 100%.
+     * @type {Number}
+     * @name PIXI.sound.SoundInstance#_end
+     * @private
+     */
+    private _end: number;
 
     /**
      * Length of the sound in seconds.
@@ -149,8 +173,10 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
      * @param {Number} [end] The ending position in seconds.
      * @param {Number} [speed] Override the default speed.
      * @param {Boolean} [loop] Override the default loop.
+     * @param {Number} [fadeIn] Time to fadein volume.
+     * @param {Number} [fadeOut] Time to fadeout volume.
      */
-    public play(start: number = 0, end?: number, speed?: number, loop?: boolean): void
+    public play(start: number, end: number, speed: number, loop: boolean, fadeIn: number, fadeOut: number): void
     {
         // @if DEBUG
         if (end)
@@ -178,9 +204,35 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
             // @endif
             this._source.loop = false;
         }
+        this._end = end;
+
+        const duration: number = this._source.buffer.duration;
+        
+        fadeIn = this._toSec(fadeIn);
+
+        // Clamp fadeIn to the duration
+        if (fadeIn > duration)
+        {
+            fadeIn = duration;
+        }
+
+        // Cannot fade out for looping sounds
+        if (!this._source.loop)
+        {
+            fadeOut = this._toSec(fadeOut);
+
+            // Clamp fadeOut to the duration + fadeIn
+            if (fadeOut > duration - fadeIn)
+            {
+                fadeOut = duration - fadeIn;
+            } 
+        }
+
+        this._duration = duration;
+        this._fadeIn = fadeIn;
+        this._fadeOut = fadeOut;
         this._lastUpdate = this._now();
         this._elapsed = start;
-        this._duration = this._source.buffer.duration;
         this._source.onended = this._onComplete.bind(this);
         this._source.start(0, start, (end ? end - start : undefined));
 
@@ -195,6 +247,22 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
 
         // Start handling internal ticks
         this._enabled = true;
+    }
+
+    /**
+     * Utility to convert time in millseconds or seconds
+     * @method PIXI.sound.SoundInstance#_toSec
+     * @private
+     * @param {Number} [time] Time in either ms or sec
+     * @return {Number} Time in seconds
+     */
+    private _toSec(time?: number): number
+    {
+        if (time > 10)
+        {
+            time /= 1000;
+        }
+        return time || 0;
     }
 
     /**
@@ -256,7 +324,14 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
                 this.emit("resumed");
 
                 // resume the playing with offset
-                this.play(this._elapsed % this._duration);
+                this.play(
+                    this._elapsed % this._duration,
+                    this._end,
+                    this._speed,
+                    this._source.loop,
+                    this._fadeIn,
+                    this._fadeOut
+                );
             }
 
             /**
@@ -280,10 +355,17 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
         {
             this._source.onended = null;
         }
+        // reset the volume back to original
+        this._parent.volume = this._parent.volume;
+
         this._source = null;
+        this._speed = 0;
+        this._end = 0;
         this._parent = null;
         this._elapsed = 0;
         this._duration = 0;
+        this._fadeIn = 0;
+        this._fadeOut = 0;
         this._paused = false;
 
         // Add it if it isn't already added
@@ -332,7 +414,38 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
                 this._elapsed += delta;
                 this._lastUpdate = now;
                 const duration: number = this._duration;
-                this._progress = ((this._elapsed * this._speed) % duration) / duration;
+                const progress: number = ((this._elapsed * this._speed) % duration) / duration;
+                
+                if (this._fadeIn || this._fadeOut)
+                {
+                    const position: number = progress * duration;
+                    const gain = this._parent.nodes.gain.gain;
+                    const maxVolume = this._parent.volume;
+
+                    if (this._fadeIn)
+                    {
+                        if (position <= this._fadeIn && progress < 1)
+                        {
+                            // Manipulate the gain node directly
+                            // so we can maintain the starting volume
+                            gain.value = maxVolume * (position / this._fadeIn);
+                        }
+                        else
+                        {
+                            gain.value = maxVolume;
+                            this._fadeIn = 0;
+                        }
+                    }
+
+                    if (this._fadeOut && position >= duration - this._fadeOut)
+                    {
+                        const percent: number = (duration - position) / this._fadeOut;
+                        gain.value = maxVolume * percent;
+                    }
+                }
+
+                // Update the progress
+                this._progress = progress;
 
                 /**
                  * The sound progress is updated.
@@ -368,7 +481,6 @@ export default class SoundInstance extends PIXI.utils.EventEmitter
             this._source.onended = null;
             this._source.stop();
             this._source = null;
-
         }
     }
 

--- a/src/SoundLibrary.ts
+++ b/src/SoundLibrary.ts
@@ -358,10 +358,11 @@ export default class SoundLibrary
      * @param {Number} [options.end] End time offset.
      * @param {Number} [options.speed] Override default speed, default to the Sound's speed setting.
      * @param {Boolean} [options.loop] Override default loop, default to the Sound's loop setting.
-     * @return {PIXI.sound.SoundInstance|null} The sound instance, this cannot be reused
-     *         after it is done playing. Returns `null` if the sound has not yet loaded.
+     * @return {PIXI.sound.SoundInstance|Promise<PIXI.sound.SoundInstance>} The sound instance,
+     *        this cannot be reused after it is done playing. Returns a Promise if the sound
+     *        has not yet loaded.
      */
-    public play(alias: string, options?: PlayOptions|Object|string): SoundInstance
+    public play(alias: string, options?: PlayOptions|Object|string): SoundInstance|Promise<SoundInstance>
     {
         return this.find(alias).play(options);
     }

--- a/src/SoundSprite.ts
+++ b/src/SoundSprite.ts
@@ -79,9 +79,9 @@ export default class SoundSprite
      * Play the sound sprite.
      * @method PIXI.sound.SoundSprite#play
      * @param {PIXI.sound.Sound~completeCallback} [complete] Function call when complete
-     * @return {PIXI.sound.SoundInstance} Sound instance being played.
+     * @return {PIXI.sound.SoundInstance|Promise<PIXI.sound.SoundInstance>} Sound instance being played.
      */
-    public play(complete?: CompleteCallback): SoundInstance
+    public play(complete?: CompleteCallback): SoundInstance|Promise<SoundInstance>
     {
         return this.parent.play(Object.assign({
             complete,

--- a/src/deprecations.ts
+++ b/src/deprecations.ts
@@ -72,3 +72,33 @@ Object.defineProperty(SoundPrototype, "block", {
         this.singleInstance = value;
     },
 });
+
+/**
+ * Retired property on Sound for handing loaded event.
+ * @name PIXI.sound.Sound#loaded
+ * @deprecated since 1.4.0
+ */
+Object.defineProperty(SoundPrototype, "loaded", {
+    get() {
+        console.warn("PIXI.sound.Sound.prototype.loaded is deprecated, use constructor option instead");
+        return null;
+    },
+    set(value: boolean) {
+        console.warn("PIXI.sound.Sound.prototype.loaded is deprecated, use constructor option instead");
+    },
+});
+
+/**
+ * Retired property on Sound for handling autoPlay completed event.
+ * @name PIXI.sound.Sound#complete
+ * @deprecated since 1.4.0
+ */
+Object.defineProperty(SoundPrototype, "complete", {
+    get() {
+        console.warn("PIXI.sound.Sound.prototype.complete is deprecated, use constructor option instead");
+        return null;
+    },
+    set(value: boolean) {
+        console.warn("PIXI.sound.Sound.prototype.complete is deprecated, use constructor option instead");
+    },
+});

--- a/test/index.js
+++ b/test/index.js
@@ -259,6 +259,43 @@ describe("PIXI.sound", function()
     });
 });
 
+describe("PIXI.sound.SoundInstance", function()
+{
+    afterEach(function()
+    {
+        library.default.removeAll();
+    });
+
+    it("should return Promise for playing unloaded sound", function(done)
+    {
+        const Sound = library.default.Sound;
+        const sound = Sound.from(manifest.silence);
+        expect(sound).to.be.instanceof(Sound);
+        const promise = sound.play();
+        promise.then((instance) => {
+            expect(instance).to.be.instanceof(library.default.SoundInstance);
+            done();
+        });
+        expect(promise).to.be.instanceof(Promise);
+    });
+
+    it("should return instance for playing loaded sound", function(done)
+    {
+        const sound = library.default.Sound.from({
+            src: manifest.silence,
+            preload: true,
+            loaded: (err) => {
+                expect(err).to.be.null;
+                expect(sound.isLoaded).to.be.true;
+                expect(sound.isPlayable).to.be.true;
+                const instance = sound.play();
+                expect(instance).to.be.instanceof(library.default.SoundInstance);
+                done();
+            },
+        });
+    });
+});
+
 describe("PIXI.loader", function()
 {
     afterEach(function()


### PR DESCRIPTION
### Added

* Adds `fadeIn` and `fadeOut` to play options.
* `play` now returns a Promise for getting the instance being played if the current sound has not been loaded yet.

### Fixed

* Fixes maintaining play options with `autoPlay`

### Deprecate

* Deprecates the `loaded` property of Sound. Use the constructor or the play options instead.
* Deprecates the `complete` property of Sound. Use the constructor or the play options instead.

Implements feature #4