### PR TITLE
Drops support for loading using fs.readFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ WebAudio API playback library, with filters. Modern audio playback for modern br
 
 * Pausing and resuming
 * Independent volume control
-* Loading with XMLHttpRequest or Node's `fs` module
 * Support blocking or layered sounds (multiple instances)
 * Support for `PIXI.loader` system
 * Dynamic filters:

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -22,7 +22,6 @@ export interface Options {
     loop?: boolean;
     url?: string;
     source?: ArrayBuffer|HTMLAudioElement;
-    useXHR?: boolean;
     sprites?: {[id: string]: SoundSpriteData};
 }
 
@@ -213,8 +212,6 @@ export default class Sound
      * @param {boolean} [options.preload=false] true to immediately start preloading.
      * @param {boolean} [options.singleInstance=false] `true` to disallow playing multiple layered instances at once.
      * @param {number} [options.volume=1] The amount of volume 1 = 100%.
-     * @param {boolean} [options.useXHR=true] true to use XMLHttpRequest to load the sound. Default is false,
-     *        loaded with NodeJS's `fs` module.
      * @param {number} [options.speed=1] The playback rate where 1 is 100% speed.
      * @param {Object} [options.sprites] The map of sprite data. Where a sprite is an object
      *        with a `start` and `end`, which are the times in seconds. Optionally, can include
@@ -254,7 +251,6 @@ export default class Sound
             complete: null,
             loaded: null,
             loop: false,
-            useXHR: true,
         }, options);
 
         // Resolve url in-case it has a special format

--- a/src/SoundLibrary.ts
+++ b/src/SoundLibrary.ts
@@ -248,8 +248,6 @@ export default class SoundLibrary
      * @param {boolean} [options.singleInstance=false] `true` to disallow playing multiple layered instances at once.
      * @param {number} [options.volume=1] The amount of volume 1 = 100%.
      * @param {number} [options.speed=1] The playback rate where 1 is 100% speed.
-     * @param {boolean} [options.useXHR=true] true to use XMLHttpRequest to load the sound. Default is false,
-     *        loaded with NodeJS's `fs` module.
      * @param {Object} [options.sprites] The map of sprite data. Where a sprite is an object
      *        with a `start` and `end`, which are the times in seconds. Optionally, can include
      *        a `speed` amount where 1 is 100% speed.

--- a/src/webaudio/WebAudioMedia.ts
+++ b/src/webaudio/WebAudioMedia.ts
@@ -35,15 +35,6 @@ export default class WebAudioMedia implements IMedia
     public source: ArrayBuffer;
 
     /**
-     * `true` to use XMLHttpRequest object to load.
-     * Default is to use NodeJS's fs module to read the sound.
-     * @name PIXI.sound.webaudio.WebAudioMedia#useXHR
-     * @type {boolean}
-     * @default false
-     */
-    public useXHR: boolean;
-
-    /**
      * Instance of the chain builder.
      * @name PIXI.sound.webaudio.WebAudioMedia#_nodes
      * @type {PIXI.sound.webaudio.WebAudioNodes}
@@ -65,7 +56,6 @@ export default class WebAudioMedia implements IMedia
         this._nodes = new WebAudioNodes(this.context);
         this._source = this._nodes.bufferSource;
         this.source = parent.options.source as ArrayBuffer;
-        this.useXHR = parent.options.useXHR;
     }
 
     /**
@@ -150,7 +140,7 @@ export default class WebAudioMedia implements IMedia
         // Load from the file path
         if (this.parent.url)
         {
-            this.useXHR ? this._loadUrl(callback) : this._loadPath(callback);
+            this._loadUrl(callback);
         }
         // Load from the arraybuffer, incase it was loaded outside
         else if (this.source)
@@ -187,38 +177,6 @@ export default class WebAudioMedia implements IMedia
 
         // actually start the request
         request.send();
-    }
-
-    /**
-     * Loads using the file system (NodeJS's fs module).
-     * @method PIXI.sound.webaudio.WebAudioMedia#_loadPath
-     * @private
-     */
-    private _loadPath(callback?: LoadedCallback)
-    {
-        const fs = require("fs");
-        const url: string = this.parent.url;
-        fs.readFile(url, (err: Error, data: Buffer) => {
-            if (err)
-            {
-                // @if DEBUG
-                console.error(err);
-                // @endif
-                if (callback)
-                {
-                    callback(new Error(`File not found ${this.parent.url}`));
-                }
-                return;
-            }
-            const arrayBuffer = new ArrayBuffer(data.length);
-            const view = new Uint8Array(arrayBuffer);
-            for (let i = 0; i < data.length; ++i)
-            {
-                view[i] = data[i];
-            }
-            this.source = arrayBuffer;
-            this._decode(arrayBuffer, callback);
-        });
     }
 
     /**

--- a/test/index.js
+++ b/test/index.js
@@ -74,26 +74,6 @@ module.exports = function(libraryPath, useLegacy)
             expect(htmlaudio).to.equal(PIXI.sound.htmlaudio);
         });
 
-        it("should load file with Node's filesystem", webAudioOnly(function(done)
-        {
-            sound.add("silence",
-            {
-                preload: true,
-                url: manifest.silence,
-                useXHR: false,
-                loaded: (err, s) => {
-                    expect(s.isLoaded).to.be.true;
-                    expect(s.isPlayable).to.be.true;
-                    expect(s.autoPlay).to.be.false;
-                    expect(s.loop).to.be.false;
-                    expect(s.preload).to.be.true;
-                    expect(s).to.be.instanceof(Sound);
-                    sound.removeAll();
-                    done();
-                },
-            });
-        }));
-
         it("should load a manifest", function(done)
         {
             this.slow(200);


### PR DESCRIPTION
Fixes #28

This removes loading WebAudio use Node's `fs` module. This was implemented in v1 for very specific reasons which are more edge-case now. It was only intended for Electron projects to not have the loading throttle Chrome events (like rendering). This functionality could easily be implement in projects by loading the the source as an `ArrayBuffer` and passing that to `PIXI.sound.add` or `PIXI.sound.Sound.from`.

```js
const fs = require("fs");
fs.readFile(url, (err: Error, data: Buffer) => {
    const arrayBuffer = new ArrayBuffer(data.length);
    const view = new Uint8Array(arrayBuffer);
    for (let i = 0; i < data.length; ++i) {
        view[i] = data[i];
    }
    const sound = PIXI.sound.Sound.from(arrayBuffer);
});
```