### PR TITLE
Adds methods to close/init library, removes opt-in global object

### DIFF
--- a/pixi-sound.d.ts
+++ b/pixi-sound.d.ts
@@ -3,7 +3,6 @@ declare namespace PIXI.sound {
     // SoundLibrary
     const context: IMediaContext;
     const supported: boolean;
-    function global(): void;
     let useLegacy: boolean;
     let volumeAll: number;
     let speedAll: number;
@@ -31,6 +30,8 @@ declare namespace PIXI.sound {
     function volume(alias: string, volume?: number): number;
     function speed(alias: string, speed?: number): number;
     function duration(alias: string): number;
+    function init(): typeof PIXI.sound;
+    function close(): typeof PIXI.sound;
     // end: SoundLibrary
     class Filter {
         destination: AudioNode;

--- a/src/SoundLibrary.ts
+++ b/src/SoundLibrary.ts
@@ -79,6 +79,18 @@ export default class SoundLibrary
 
     constructor()
     {
+        this.init();
+    }
+
+    /**
+     * Re-initialize the sound library, this will
+     * recreate the AudioContext. If there's a hardware-failure
+     * call `close` and then `init`.
+     * @method PIXI.sound#init
+     * @return {PIXI.sound} Sound instance
+     */
+    public init(): SoundLibrary
+    {
         if (this.supported)
         {
             this._webAudioContext = new WebAudioContext();
@@ -86,6 +98,7 @@ export default class SoundLibrary
         this._htmlAudioContext = new HTMLAudioContext();
         this._sounds = {};
         this.useLegacy = !this.supported;
+        return this;
     }
 
     /**
@@ -134,40 +147,18 @@ export default class SoundLibrary
             delete (window as any).__pixiSound;
         }
 
-        // Webpack and NodeJS-like environments will not expose
-        // the library to the window by default, user must opt-in
-        if (typeof module === "undefined")
-        {
-            instance.global();
-        }
-
-        return instance;
-    }
-
-    /**
-     * Set the `PIXI.sound` window namespace object. By default
-     * the global namespace is disabled in environments that use
-     * require/module (e.g. Webpack), so `PIXI.sound` would not
-     * be accessible these environments. Window environments
-     * will automatically expose the window object, calling this
-     * method will do nothing.
-     * @method PIXI.sound#global
-     * @example
-     * import {sound} from 'pixi-sound';
-     * sound.global(); // Now can use PIXI.sound
-     */
-    public global(): void
-    {
+        // Expose to PIXI.sound to the window PIXI object
         const PixiJS = PIXI as any;
 
+        // Check incase sound has already used
         if (!PixiJS.sound)
         {
             Object.defineProperty(PixiJS, "sound",
             {
-                get() { return SoundLibrary.instance; },
+                get() { return instance; },
             });
 
-            Object.defineProperties(SoundLibrary.instance,
+            Object.defineProperties(instance,
             {
                 filters: { get() { return filters; } },
                 htmlaudio: { get() { return htmlaudio; } },
@@ -179,6 +170,8 @@ export default class SoundLibrary
                 SoundLibrary: { get() { return SoundLibrary; } },
             });
         }
+
+        return instance;
     }
 
     /**
@@ -629,14 +622,27 @@ export default class SoundLibrary
     }
 
     /**
-     * Destroys the sound module.
-     * @method PIXI.sound#destroy
-     * @private
+     * Closes the sound library. This will release/destroy
+     * the AudioContext(s). Can be used safely if you want to
+     * initialize the sound library later. Use `init` method.
+     * @method PIXI.sound#close
+     * @return {PIXI.sound}
      */
-    public destroy(): void
+    public close(): SoundLibrary
     {
         this.removeAll();
         this._sounds = null;
+        if (this._webAudioContext)
+        {
+            this._webAudioContext.destroy();
+            this._webAudioContext = null;
+        }
+        if (this._htmlAudioContext)
+        {
+            this._htmlAudioContext.destroy();
+            this._htmlAudioContext = null;
+        }
         this._context = null;
+        return this;
     }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -53,8 +53,6 @@ module.exports = function(libraryPath, useLegacy)
 
         it("should have the correct classes", function()
         {
-            sound.global(); // Install globally at PIXI.sound
-
             expect(PIXI.sound).to.be.a.function;
             expect(PIXI.sound.Sound).to.be.a.function;
             expect(PIXI.sound.utils).to.be.a.function;
@@ -72,6 +70,12 @@ module.exports = function(libraryPath, useLegacy)
             expect(filters).to.equal(PIXI.sound.filters);
             expect(webaudio).to.equal(PIXI.sound.webaudio);
             expect(htmlaudio).to.equal(PIXI.sound.htmlaudio);
+        });
+
+        it("should recreate the library", function()
+        {
+            PIXI.sound.close().init();
+            PIXI.sound.useLegacy = !!useLegacy;
         });
 
         it("should load a manifest", function(done)


### PR DESCRIPTION
### Added

* Adds `PIXI.sound.close()` method to destroy/close/disconnect the AudioContext
* Adds `PIXI.sound.init()` method to re-create the AudioContext

### Removed

* Removes `PIXI.sound.global()`, the global object is always defined

Addresses #33

cc @cursedcoder