### PR TITLE
Support `addPixiMiddleware` for Loader override

### DIFF
--- a/src/SoundLibrary.ts
+++ b/src/SoundLibrary.ts
@@ -6,7 +6,7 @@ import * as htmlaudio from "./htmlaudio";
 import {HTMLAudioContext} from "./htmlaudio";
 import {IMediaContext} from "./interfaces/IMediaContext";
 import {IMediaInstance} from "./interfaces/IMediaInstance";
-import LoaderMiddleware from "./loader";
+import LoaderMiddleware from "./loader/LoaderMiddleware";
 import {CompleteCallback, Options, PlayOptions} from "./Sound";
 import Sound from "./Sound";
 import SoundSprite from "./sprites/SoundSprite";

--- a/src/loader/Loader.ts
+++ b/src/loader/Loader.ts
@@ -1,0 +1,35 @@
+import LoaderMiddleware from './LoaderMiddleware';
+
+/**
+ * Loader to replace the default PIXI Loader, this will
+ * provide support for auto-install `pre`, currently only the `addPixiMiddleware`
+ * method only support's **resource-loader's** `use` method.
+ * @namespace PIXI.sound.loader
+ * @class
+ * @private
+ */
+export default class Loader extends PIXI.loaders.Loader
+{
+    /**
+     * @param {string} [baseUrl=''] - The base url for all resources loaded by this loader.
+     * @param {number} [concurrency=10] - The number of resources to load concurrently.
+     */
+    constructor(baseUrl?:string, concurrency?:number)
+    {
+        super(baseUrl, concurrency);
+
+        this.use(LoaderMiddleware.plugin);
+        this.pre(LoaderMiddleware.resolve);
+    }
+
+    /**
+     * Adds a default middleware to the PixiJS loader.
+     *
+     * @static
+     * @param {Function} fn - The middleware to add.
+     */
+    static addPixiMiddleware(fn: () => void): void
+    {
+        PIXI.loaders.Loader.addPixiMiddleware(fn);
+    }
+}

--- a/src/loader/LoaderMiddleware.ts
+++ b/src/loader/LoaderMiddleware.ts
@@ -1,9 +1,10 @@
 import SoundLibrary from "../SoundLibrary";
 import SoundUtils from "../utils/SoundUtils";
+import Loader from "./Loader";
 
 /**
  * Sound middleware installation utilities for PIXI.loaders.Loader
- * @namespace PIXI.sound.loader
+ * @class
  * @private
  */
 export default class LoaderMiddleware
@@ -26,16 +27,9 @@ export default class LoaderMiddleware
         LoaderMiddleware._sound = sound;
         LoaderMiddleware.legacy = sound.useLegacy;
 
-        // Monkey-patch the PIXI.loaders.Loader class
+        // Replace the PIXI.loaders.Loader class
         // to support using the resolve loader middleware
-        const Loader = PIXI.loaders.Loader;
-        const SoundLoader = function(baseUrl?:string, concurrency?:number) {
-            Loader.call(this, baseUrl, concurrency);
-            this.use(LoaderMiddleware.plugin);
-            this.pre(LoaderMiddleware.resolve);
-        };
-        SoundLoader.prototype = Loader.prototype;
-        (PIXI.loaders as any).Loader = SoundLoader;
+        PIXI.loaders.Loader = Loader;
 
         // Install middleware on the default loader
         PIXI.loader.use(LoaderMiddleware.plugin);
@@ -76,7 +70,7 @@ export default class LoaderMiddleware
     /**
      * Handle the preprocessing of file paths
      */
-    private static resolve(resource: PIXI.loaders.Resource, next: () => void): void
+    static resolve(resource: PIXI.loaders.Resource, next: () => void): void
     {
         SoundUtils.resolveUrl(resource);
         next();
@@ -85,7 +79,7 @@ export default class LoaderMiddleware
     /**
      * Actual resource-loader middleware for sound class
      */
-    private static plugin(resource: PIXI.loaders.Resource, next: () => void): void
+    static plugin(resource: PIXI.loaders.Resource, next: () => void): void
     {
         if (resource.data && SoundUtils.extensions.indexOf(resource.extension) > -1)
         {


### PR DESCRIPTION
Since PixiSound overrides the Loader, it needs to provide a pass-thru method for `addPixiMiddleware` to not break other 3rd-party middleware with PixiJS.

cc @cursedcoder 

Fixes #37