### PR TITLE
PIXI.loaders.Loader loading WebAudioMedia twice

### DIFF
--- a/src/webaudio/WebAudioMedia.ts
+++ b/src/webaudio/WebAudioMedia.ts
@@ -137,15 +137,15 @@ export default class WebAudioMedia implements IMedia
     // Implements load
     public load(callback?: LoadedCallback): void
     {
-        // Load from the file path
-        if (this.parent.url)
-        {
-            this._loadUrl(callback);
-        }
         // Load from the arraybuffer, incase it was loaded outside
-        else if (this.source)
+        if (this.source)
         {
             this._decode(this.source, callback);
+        }
+        // Load from the file path
+        else if (this.parent.url)
+        {
+            this._loadUrl(callback);
         }
         else if (callback)
         {


### PR DESCRIPTION
Bug in the WebAudioMedia load call should have been prioritizing decoding audio over loading. Assets loaded with PIXI.loaders.Loader no longer load assets twice.