### PR TITLE
 Fixes iOS11 bug 

### DIFF
--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -96,6 +96,7 @@ export default class WebAudioContext extends Filterable implements IMediaContext
 
     constructor()
     {
+        const win: any = window as any;
         const ctx = new WebAudioContext.AudioContext();
         const compressor: DynamicsCompressorNode = ctx.createDynamicsCompressor();
         const analyser: AnalyserNode = ctx.createAnalyser();
@@ -107,7 +108,7 @@ export default class WebAudioContext extends Filterable implements IMediaContext
         super(analyser, compressor);
 
         this._ctx = ctx;
-        this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2, ctx.sampleRate);
+        this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2, (win.webkitAudioContext)? 44100 : ctx.sampleRate);
         this._unlocked = false;
 
         this.compressor = compressor;

--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -108,7 +108,7 @@ export default class WebAudioContext extends Filterable implements IMediaContext
         super(analyser, compressor);
 
         this._ctx = ctx;
-        this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2, (win.webkitAudioContext)? 44100 : ctx.sampleRate);
+        this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2, (win.OfflineAudioContext)? ctx.sampleRate: 44100);
         this._unlocked = false;
 
         this.compressor = compressor;

--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -108,6 +108,7 @@ export default class WebAudioContext extends Filterable implements IMediaContext
         super(analyser, compressor);
 
         this._ctx = ctx;
+        // ios11 safari's webkitOfflineAudioContext allows only 44100 Hz sample rate
         this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2, (win.OfflineAudioContext)? ctx.sampleRate: 44100);
         this._unlocked = false;
 


### PR DESCRIPTION
ios11 safari's webkitOfflineAudioContext allows only 44100 Hz sample rate
if not set 44100 Hz, safari is throw exception "SyntaxError: The string did not match the expected pattern.."

