### PR TITLE
Sound sprite looping enabled for WebAudio

### DIFF
--- a/examples/client/sprites.js
+++ b/examples/client/sprites.js
@@ -5,7 +5,8 @@ var $$ = document.querySelectorAll.bind(document);
 var sprites = {
     'alien death': {
         start: 1, 
-        end: 2
+        end: 2,
+        loop: true
     },
     'boss hit': {
         start: 3, 

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="css/range.css">
         <link rel="stylesheet" href="css/examples.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/languages/javascript.min.js"></script>
-        <script src="https://pixijs.download/v4.8.4/pixi.min.js"></script>
+        <script src="https://pixijs.download/v4.x/pixi.min.js"></script>
         <script src="../dist/pixi-sound.js"></script>
     </head>
     <body ontouchstart="">

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="css/range.css">
         <link rel="stylesheet" href="css/examples.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/languages/javascript.min.js"></script>
-        <script src="https://pixijs.download/dev/pixi.min.js"></script>
+        <script src="https://pixijs.download/v4.8.4/pixi.min.js"></script>
         <script src="../dist/pixi-sound.js"></script>
     </head>
     <body ontouchstart="">

--- a/examples/filters.html
+++ b/examples/filters.html
@@ -12,7 +12,7 @@
         <link rel="stylesheet" href="css/examples.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/languages/javascript.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html5sortable/0.6.0/html.sortable.min.js"></script>
-        <script src="https://pixijs.download/v4.8.4/pixi.min.js"></script>
+        <script src="https://pixijs.download/v4.x/pixi.min.js"></script>
         <script src="../dist/pixi-sound.js"></script>
     </head>
     <body>

--- a/examples/filters.html
+++ b/examples/filters.html
@@ -12,7 +12,7 @@
         <link rel="stylesheet" href="css/examples.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/languages/javascript.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html5sortable/0.6.0/html.sortable.min.js"></script>
-        <script src="https://pixijs.download/dev/pixi.min.js"></script>
+        <script src="https://pixijs.download/v4.8.4/pixi.min.js"></script>
         <script src="../dist/pixi-sound.js"></script>
     </head>
     <body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,7 +13,7 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
         <script src="https://cdn.rawgit.com/aidanlister/jquery-stickytabs/1.2.1/jquery.stickytabs.js"></script>
-        <script src="https://pixijs.download/v4.8.4/pixi.min.js"></script>
+        <script src="https://pixijs.download/v4.x/pixi.min.js"></script>
         <script src="../dist/pixi-sound.js"></script>
     </head>
     <body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,7 +13,7 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
         <script src="https://cdn.rawgit.com/aidanlister/jquery-stickytabs/1.2.1/jquery.stickytabs.js"></script>
-        <script src="https://pixijs.download/dev/pixi.min.js"></script>
+        <script src="https://pixijs.download/v4.8.4/pixi.min.js"></script>
         <script src="../dist/pixi-sound.js"></script>
     </head>
     <body>

--- a/examples/sprites.html
+++ b/examples/sprites.html
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="css/examples.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/monokai-sublime.min.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/languages/javascript.min.js"></script>
-        <script src="https://pixijs.download/dev/pixi.min.js"></script>
+        <script src="https://pixijs.download/v4.8.4/pixi.min.js"></script>
         <script src="../dist/pixi-sound.js"></script>
     </head>
     <body>

--- a/examples/sprites.html
+++ b/examples/sprites.html
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="css/examples.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/monokai-sublime.min.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/languages/javascript.min.js"></script>
-        <script src="https://pixijs.download/v4.8.4/pixi.min.js"></script>
+        <script src="https://pixijs.download/v4.x/pixi.min.js"></script>
         <script src="../dist/pixi-sound.js"></script>
     </head>
     <body>

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -554,7 +554,7 @@ export default class Sound
         if (typeof source === "string")
         {
             const sprite: string = source as string;
-            options = { sprite, complete };
+            options = { sprite, loop: this.loop, complete };
         }
         else if (typeof source === "function")
         {
@@ -589,6 +589,7 @@ export default class Sound
             options.start = sprite.start;
             options.end = sprite.end;
             options.speed = sprite.speed || 1;
+            options.loop = sprite.loop || options.loop;
             delete options.sprite;
         }
 

--- a/src/sprites/SoundSprite.ts
+++ b/src/sprites/SoundSprite.ts
@@ -65,6 +65,14 @@ export default class SoundSprite
      */
     public duration: number;
 
+     /**
+     * Whether to loop the sound sprite.
+     * @name PIXI.sound.SoundSprite#loop
+     * @type {boolean}
+     * @readonly
+     */
+    public loop: boolean;
+
     /**
      * Constructor
      */
@@ -92,6 +100,7 @@ export default class SoundSprite
             speed: this.speed || this.parent.speed,
             end: this.end,
             start: this.start,
+            loop: this.loop
         }));
     }
 


### PR DESCRIPTION
I needed this feature quite badly so i've implemented it hopefully in a not-too-hacky way.
The loop option can be set either on the individual sound sprite definitions or the sound object.
I changed the example pixi versions because it didn't seem to work with Pixi v5.