### PR TITLE
Select buffer size automatically by setting 0

### DIFF
--- a/src/webaudio/WebAudioNodes.ts
+++ b/src/webaudio/WebAudioNodes.ts
@@ -25,14 +25,6 @@ export interface SourceClone {
 export class WebAudioNodes extends Filterable
 {
     /**
-     * The buffer size for script processor
-     * @name PIXI.sound.SoundNodes.BUFFER_SIZE
-     * @type {number}
-     * @default 256
-     */
-    public static BUFFER_SIZE: number = 256;
-
-    /**
      * Get the buffer source node
      * @name PIXI.sound.SoundNodes#bufferSource
      * @type {AudioBufferSourceNode}
@@ -77,7 +69,7 @@ export class WebAudioNodes extends Filterable
         const audioContext: AudioContext = context.audioContext;
 
         const bufferSource: AudioBufferSourceNode = audioContext.createBufferSource();
-        const script: ScriptProcessorNode = audioContext.createScriptProcessor(WebAudioNodes.BUFFER_SIZE);
+        const script: ScriptProcessorNode = audioContext.createScriptProcessor(0);
         const gain: GainNode = audioContext.createGain();
         const analyser: AnalyserNode = audioContext.createAnalyser();
 

--- a/src/webaudio/WebAudioNodes.ts
+++ b/src/webaudio/WebAudioNodes.ts
@@ -126,4 +126,14 @@ export class WebAudioNodes extends Filterable
         gain.connect(this.destination);
         return { source, gain };
     }
+
+    /**
+     * Get buffer size of `ScriptProcessorNode`.
+     * @type {number}
+     * @readonly
+     */
+    get bufferSize(): number
+    {
+        return this.script.bufferSize;
+    }
 }


### PR DESCRIPTION
See [The ScriptProcessorNode Interface](https://www.w3.org/TR/webaudio/).

> if the value is 0, then the implementation will choose the best buffer size for the given environment, which will be constant power of 2 throughout the lifetime of the node.