### PR TITLE
Don't depend on ScriptProcessorNode for update event

### DIFF
--- a/src/webaudio/WebAudioInstance.ts
+++ b/src/webaudio/WebAudioInstance.ts
@@ -126,14 +126,6 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
     private _progress: number;
 
     /**
-     * Callback for update listener
-     * @type {EventListener}
-     * @name PIXI.sound.webaudio.WebAudioInstance#_updateListener
-     * @private
-     */
-    private _updateListener: EventListener;
-
-    /**
      * Audio buffer source clone from Sound object.
      * @type {AudioBufferSourceNode}
      * @name PIXI.sound.webaudio.WebAudioInstance#_source
@@ -150,7 +142,6 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
         this._paused = false;
         this._muted = false;
         this._elapsed = 0;
-        this._updateListener = this._update.bind(this) as EventListener;
 
         // Initialize
         this.init(media);
@@ -400,13 +391,10 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
      */
     private set _enabled(enabled: boolean)
     {
-        const script = this._media.nodes.script;
-
-        script.removeEventListener("audioprocess", this._updateListener);
-
+        PIXI.ticker.shared.remove(this._updateListener, this);
         if (enabled)
         {
-            script.addEventListener("audioprocess", this._updateListener);
+            PIXI.ticker.shared.add(this._updateListener, this);
         }
     }
 
@@ -491,6 +479,16 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
     private _now(): number
     {
         return this._media.context.audioContext.currentTime;
+    }
+
+    /**
+     * Callback for update listener
+     * @type {Function}
+     * @name PIXI.sound.webaudio.WebAudioInstance#_updateListener
+     * @private
+     */
+    private _updateListener() {
+        this._update();
     }
 
     /**

--- a/src/webaudio/WebAudioNodes.ts
+++ b/src/webaudio/WebAudioNodes.ts
@@ -25,6 +25,15 @@ export interface SourceClone {
 export class WebAudioNodes extends Filterable
 {
     /**
+     * The buffer size for script processor, default is `0` which auto-detects. If you plan to use
+     * script node on iOS, you'll need to provide a non-zero amount.
+     * @name PIXI.sound.SoundNodes.BUFFER_SIZE
+     * @type {number}
+     * @default 0
+     */
+    public static BUFFER_SIZE: number = 0;
+
+    /**
      * Get the buffer source node
      * @name PIXI.sound.SoundNodes#bufferSource
      * @type {AudioBufferSourceNode}
@@ -93,7 +102,7 @@ export class WebAudioNodes extends Filterable
     {
         if (!this._script)
         {
-            this._script = this.context.audioContext.createScriptProcessor(0);
+            this._script = this.context.audioContext.createScriptProcessor(WebAudioNodes.BUFFER_SIZE);
             this._script.connect(this.context.destination);
         }
         return this._script;

--- a/src/webaudio/WebAudioNodes.ts
+++ b/src/webaudio/WebAudioNodes.ts
@@ -33,14 +33,6 @@ export class WebAudioNodes extends Filterable
     public bufferSource: AudioBufferSourceNode;
 
     /**
-     * Get the script processor node.
-     * @name PIXI.sound.SoundNodes#script
-     * @type {ScriptProcessorNode}
-     * @readonly
-     */
-    public script: ScriptProcessorNode;
-
-    /**
      * Get the gain node
      * @name PIXI.sound.SoundNodes#gain
      * @type {GainNode}
@@ -64,27 +56,47 @@ export class WebAudioNodes extends Filterable
      */
     public context: WebAudioContext;
 
+    /**
+     * Private reference to the script processor node.
+     * @name PIXI.sound.SoundNodes#_script
+     * @type {ScriptProcessorNode}
+     */
+    private _script: ScriptProcessorNode;
+
     constructor(context: WebAudioContext)
     {
         const audioContext: AudioContext = context.audioContext;
 
         const bufferSource: AudioBufferSourceNode = audioContext.createBufferSource();
-        const script: ScriptProcessorNode = audioContext.createScriptProcessor(0);
         const gain: GainNode = audioContext.createGain();
         const analyser: AnalyserNode = audioContext.createAnalyser();
 
         bufferSource.connect(analyser);
         analyser.connect(gain);
         gain.connect(context.destination);
-        script.connect(context.destination);
 
         super(analyser, gain);
 
         this.context = context;
         this.bufferSource = bufferSource;
-        this.script = script;
         this.gain = gain;
         this.analyser = analyser;
+    }
+
+    /**
+     * Get the script processor node.
+     * @name PIXI.sound.SoundNodes#script
+     * @type {ScriptProcessorNode}
+     * @readonly
+     */
+    public get script()
+    {
+        if (!this._script)
+        {
+            this._script = this.context.audioContext.createScriptProcessor(0);
+            this._script.connect(this.context.destination);
+        }
+        return this._script;
     }
 
     /**
@@ -96,12 +108,15 @@ export class WebAudioNodes extends Filterable
         super.destroy();
 
         this.bufferSource.disconnect();
-        this.script.disconnect();
+        if (this._script)
+        {
+            this._script.disconnect();
+        }
         this.gain.disconnect();
         this.analyser.disconnect();
 
         this.bufferSource = null;
-        this.script = null;
+        this._script = null;
         this.gain = null;
         this.analyser = null;
 


### PR DESCRIPTION
Eliminates dependency on ScriptProcessorNodes for tracking audio playback progress. Made consistent with method used in legacy mode. 

ScriptProcessorNode is still available on-demand, at the same location it could be found previously, for those who need to do advanced processing.

 Addresses [#104](https://github.com/pixijs/pixi-sound/issues/104)
