### PR TITLE
Fix for removing deprecations from pixi.js v5.2.0

### DIFF
--- a/pixi-sound.d.ts
+++ b/pixi-sound.d.ts
@@ -197,7 +197,7 @@ declare namespace PIXI.sound {
     class SoundUtils {
         static extensions: string[];
         static supported: ExtensionMap;
-        static resolveUrl(source: string | PIXI.loaders.Resource): string;
+        static resolveUrl(source: string | PIXI.LoaderResource): string;
         static sineTone(hertz?: number, seconds?: number): Sound;
         static render(sound: Sound, options?: RenderOptions): PIXI.BaseTexture;
         static playOnce(url: string, callback?: (err?: Error) => void): string;


### PR DESCRIPTION
Fixes #114 