### PR TITLE
Support delayed start for playback

### DIFF
--- a/pixi-sound.d.ts
+++ b/pixi-sound.d.ts
@@ -72,6 +72,7 @@ declare namespace PIXI.sound {
         muted?: boolean;
         complete?: CompleteCallback;
         loaded?: LoadedCallback;
+        wait?: number;
     }
     type LoadedCallback = (err: Error, sound?: Sound, instance?: IMediaInstance) => void;
     type CompleteCallback = (sound: Sound) => void;

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -32,6 +32,7 @@ export interface PlayOptions {
     muted?: boolean;
     complete?: CompleteCallback;
     loaded?: LoadedCallback;
+    wait?: number;
 }
 
 /**
@@ -534,6 +535,7 @@ export class Sound
      * @param {number} [options.volume] Current volume amount for instance.
      * @param {boolean} [options.muted] Override default muted, default to the Sound's muted setting.
      * @param {boolean} [options.loop] Override default loop, default to the Sound's loop setting.
+     * @param {number} [options.wait] Delay in seconds before starting playback
      * @param {PIXI.sound.Sound~completeCallback} [options.complete] Callback when complete.
      * @param {PIXI.sound.Sound~loadedCallback} [options.loaded] If the sound isn't already preloaded, callback when
      *        the audio has completely finished loading and decoded.

--- a/src/SoundLibrary.ts
+++ b/src/SoundLibrary.ts
@@ -459,6 +459,7 @@ export class SoundLibrary
      * @param {number} [options.end] End time offset.
      * @param {number} [options.speed] Override default speed, default to the Sound's speed setting.
      * @param {boolean} [options.loop] Override default loop, default to the Sound's loop setting.
+     * @param {number} [options.wait] Delay in seconds before starting playback
      * @return {PIXI.sound.IMediaInstance|Promise<PIXI.sound.IMediaInstance>} The sound instance,
      *        this cannot be reused after it is done playing. Returns a Promise if the sound
      *        has not yet loaded.

--- a/src/htmlaudio/HTMLAudioInstance.ts
+++ b/src/htmlaudio/HTMLAudioInstance.ts
@@ -510,7 +510,7 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
         this._pausedReal = false;
         this._paused = false;
         this._muted = false;
-        if(typeof this._waitTimer === "number"){
+        if (typeof this._waitTimer === "number") {
             window.clearTimeout(this._waitTimer);
         }
         this._wait = 0;

--- a/src/htmlaudio/HTMLAudioInstance.ts
+++ b/src/htmlaudio/HTMLAudioInstance.ts
@@ -228,7 +228,7 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
             this._source.onended = null;
             this._source.pause();
         }
-        else if (typeof this._waitTimer === "number") {
+        else if (this._waitTimer !== null) {
             window.clearTimeout(this._waitTimer);
             this._waitTimer = null;
             this._wait -= (Date.now() - this._waitStart) / 1000;
@@ -510,7 +510,7 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
         this._pausedReal = false;
         this._paused = false;
         this._muted = false;
-        if (typeof this._waitTimer === "number") {
+        if (this._waitTimer !== null) {
             window.clearTimeout(this._waitTimer);
         }
         this._wait = 0;

--- a/src/htmlaudio/HTMLAudioInstance.ts
+++ b/src/htmlaudio/HTMLAudioInstance.ts
@@ -137,7 +137,7 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
      * @name PIXI.sound.htmlaudio.HTMLAudioInstance#_waitTimer
      * @private
      */
-    private _waitTimer: number;
+    private _waitTimer: number = null;
 
     /**
      * Timestamp when playback delay was started

--- a/src/htmlaudio/HTMLAudioInstance.ts
+++ b/src/htmlaudio/HTMLAudioInstance.ts
@@ -123,6 +123,30 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
      */
     private _loop: boolean;
 
+    /**
+     * The number of seconds to wait before starting playback
+     * @type {number}
+     * @name PIXI.sound.htmlaudio.HTMLAudioInstance#_wait
+     * @private
+     */
+    private _wait: number;
+
+    /**
+     * Timer to delay playback
+     * @type {number}
+     * @name PIXI.sound.htmlaudio.HTMLAudioInstance#_waitTimer
+     * @private
+     */
+    private _waitTimer: number;
+
+    /**
+     * Timestamp when playback delay was started
+     * @type {number}
+     * @name PIXI.sound.htmlaudio.HTMLAudioInstance#_waitStart
+     * @private
+     */
+    private _waitStart: number;
+
     constructor(parent: HTMLAudioMedia)
     {
         super();
@@ -203,6 +227,10 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
         {
             this._source.onended = null;
             this._source.pause();
+        }
+        else if (this._waitTimer) {
+            window.clearTimeout(this._waitTimer);
+            this._wait -= (Date.now() - this._waitStart) / 1000;
         }
     }
 
@@ -339,6 +367,7 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
                     volume: this._volume,
                     speed: this._speed,
                     loop: this._loop,
+                    wait: this._wait,
                 });
             }
 
@@ -357,7 +386,7 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
      */
     public play(options: PlayOptions): void
     {
-        const {start, end, speed, loop, volume, muted} = options;
+        const {start, end, speed, loop, volume, muted, wait} = options;
 
         if (end)
         {
@@ -368,6 +397,7 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
         this._volume = volume;
         this._loop = !!loop;
         this._muted = muted;
+        this._wait = wait;
         this.refresh();
 
         // WebAudio doesn't support looping when a duration is set
@@ -397,7 +427,17 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
             }
         };
         this._source.onended = this._onComplete.bind(this);
-        this._source.play();
+        if (this._wait) {
+            this._waitTimer = window.setTimeout(() => {
+                this._source.play();
+                this._waitTimer = 0;
+                this._wait = 0;
+            }, this._wait * 1000);
+            this._waitStart = Date.now();
+        }
+        else {
+            this._source.play();
+        }
 
         /**
          * The sound is started.
@@ -469,6 +509,9 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
         this._pausedReal = false;
         this._paused = false;
         this._muted = false;
+        this._wait = 0;
+        this._waitStart = 0;
+        this._waitTimer = 0;
 
         if (this._media)
         {

--- a/src/htmlaudio/HTMLAudioInstance.ts
+++ b/src/htmlaudio/HTMLAudioInstance.ts
@@ -228,8 +228,9 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
             this._source.onended = null;
             this._source.pause();
         }
-        else if (this._waitTimer) {
+        else if (typeof this._waitTimer === "number") {
             window.clearTimeout(this._waitTimer);
+            this._waitTimer = null;
             this._wait -= (Date.now() - this._waitStart) / 1000;
         }
     }
@@ -509,10 +510,12 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
         this._pausedReal = false;
         this._paused = false;
         this._muted = false;
-        window.clearTimeout(this._waitTimer);
+        if(typeof this._waitTimer === "number"){
+            window.clearTimeout(this._waitTimer);
+        }
         this._wait = 0;
         this._waitStart = 0;
-        this._waitTimer = 0;
+        this._waitTimer = null;
 
         if (this._media)
         {

--- a/src/htmlaudio/HTMLAudioInstance.ts
+++ b/src/htmlaudio/HTMLAudioInstance.ts
@@ -509,6 +509,7 @@ export class HTMLAudioInstance extends PIXI.utils.EventEmitter implements IMedia
         this._pausedReal = false;
         this._paused = false;
         this._muted = false;
+        window.clearTimeout(this._waitTimer);
         this._wait = 0;
         this._waitStart = 0;
         this._waitTimer = 0;

--- a/src/webaudio/WebAudioInstance.ts
+++ b/src/webaudio/WebAudioInstance.ts
@@ -570,6 +570,7 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
             this._enabled = false;
             this._source.onended = null;
             this._source.stop(0); // param needed for iOS 8 bug
+            this._source.disconnect();
             this._source = null;
         }
     }
@@ -585,6 +586,7 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
         {
             this._enabled = false;
             this._source.onended = null;
+            this._source.disconnect();
         }
         this._source = null;
         this._progress = 1;

--- a/src/webaudio/WebAudioInstance.ts
+++ b/src/webaudio/WebAudioInstance.ts
@@ -94,6 +94,14 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
     private _end: number;
 
     /**
+     * The number of seconds to wait before starting playback
+     * @type {number}
+     * @name PIXI.sound.webaudio.WebAudioInstance#_wait
+     * @private
+     */
+    private _wait: number;
+
+    /**
      * `true` if should be looping.
      * @type {boolean}
      * @name PIXI.sound.webaudio.WebAudioInstance#_loop
@@ -285,7 +293,8 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
 
                 // resume the playing with offset
                 this.play({
-                    start: this._elapsed % this._duration,
+                    wait: this._elapsed < this._wait ? this._wait - this._elapsed : 0,
+                    start: Math.max(this._elapsed - this._wait, 0) % this._duration,
                     end: this._end,
                     speed: this._speed,
                     loop: this._loop,
@@ -312,10 +321,11 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
      * @param {boolean} options.loop If the instance is looping, defaults to sound loop
      * @param {number} options.volume Volume of the instance
      * @param {boolean} options.muted Muted state of instance
+     * @param {number} options.wait Delay in seconds before starting playback
      */
     public play(options: PlayOptions): void
     {
-        const {start, end, speed, loop, volume, muted} = options;
+        const {start, end, speed, loop, volume, muted, wait} = options;
 
         if (end)
         {
@@ -330,6 +340,7 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
         this._volume = volume;
         this._loop = !!loop;
         this._muted = muted;
+        this._wait = wait || 0;
         this.refresh();
 
         const duration: number = this._source.buffer.duration;
@@ -338,20 +349,21 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
         this._lastUpdate = this._now();
         this._elapsed = start;
         this._source.onended = this._onComplete.bind(this);
+        const when = wait ? this._now() + wait : 0;
 
         if (this._loop)
         {
             this._source.loopEnd = end;
             this._source.loopStart = start;
-            this._source.start(0, start);
+            this._source.start(when, start);
         }
         else if (end)
         {
-            this._source.start(0, start, end - start);
+            this._source.start(when, start, end - start);
         }
         else
         {
-            this._source.start(0, start);
+            this._source.start(when, start);
         }
 
         /**
@@ -454,6 +466,7 @@ export class WebAudioInstance extends PIXI.utils.EventEmitter implements IMediaI
         this._loop = false;
         this._elapsed = 0;
         this._duration = 0;
+        this._wait = 0;
         this._paused = false;
         this._muted = false;
         this._pausedReal = false;


### PR DESCRIPTION
This adds a new `PlayOptions` property, "`wait`" to allow use of the `when` parameter of `AudioBufferSourceNode.start()`, which can provide for more precise timing of audio playback than triggering audio in sync with the regular JS event loop. This new property is also supported in legacy mode, for feature parity, but offers no performance advantage in that mode.